### PR TITLE
chore: Remove grid examples that require non-required components.

### DIFF
--- a/components/03-organisms/grid/_grid-examples.twig
+++ b/components/03-organisms/grid/_grid-examples.twig
@@ -1,4 +1,6 @@
-{% if item_type == 'card' %}
+{# Since the card and cta components aren't required, we can't expect them to be here by default #}
+
+{# {% if item_type == 'card' %}
   {% include "@molecules/card/card.twig" with {
     card__extra_classes: ['grid__item'],
     card__blockname: item.card__blockname,
@@ -18,6 +20,6 @@
     cta__heading: item.cta__heading,
     cta__button_text: item.cta__button_text,
   } %}
-{% else %}
+{% else %} #}
   <div class="grid__item grid__item--example"></div>
-{% endif %}
+{# {% endif %} #}

--- a/components/03-organisms/grid/grids.stories.js
+++ b/components/03-organisms/grid/grids.stories.js
@@ -1,8 +1,8 @@
 import grid from './grid.twig';
 
 import gridData from './grid.yml';
-import gridCardData from './grid-cards.yml';
-import gridCtaData from './grid-ctas.yml';
+// import gridCardData from './grid-cards.yml';
+// import gridCtaData from './grid-ctas.yml';
 
 /**
  * Storybook Definition.
@@ -11,6 +11,6 @@ export default { title: 'Organisms/Grids' };
 
 export const defaultGrid = () => grid(gridData);
 
-export const cardGrid = () => grid({ ...gridData, ...gridCardData });
+// export const cardGrid = () => grid({ ...gridData, ...gridCardData });
 
-export const ctaGrid = () => grid({ ...gridData, ...gridCtaData });
+// export const ctaGrid = () => grid({ ...gridData, ...gridCtaData });


### PR DESCRIPTION
This fixes an error that you get on a clean install.