### PR TITLE
fix: file.includes errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "compound",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@babel/eslint-parser": "^7.12.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "compound",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@babel/eslint-parser": "^7.12.17",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint-fix": "npm run lint-js -- --fix; npm run lint-styles -- --fix",
     "lint-js": "eslint \"./components\"",
     "lint-styles": "stylelint \"./components/**/*.scss\"",
+    "postinstall": "npx patch-package",
     "prepare": "husky install",
     "prettier": "prettier \"./components\" --ignore-unknown",
     "prettier-fix": "prettier \"./components\" --write --ignore-unknown",
@@ -60,6 +61,7 @@
     "sass": "^1.42.1",
     "sass-loader": "^10.1.0",
     "style-loader": "^2.0.0",
+    "twig": "^1.15.4",
     "twig-drupal-filters": "^3.1.0",
     "twig-loader": "https://github.com/fourkitchens/twig-loader"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "sass": "^1.42.1",
     "sass-loader": "^10.1.0",
     "style-loader": "^2.0.0",
-    "twig": "^1.15.4",
     "twig-drupal-filters": "^3.1.0",
     "twig-loader": "https://github.com/fourkitchens/twig-loader"
   },

--- a/patches/twig+1.15.4.patch
+++ b/patches/twig+1.15.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/twig/twig.js b/node_modules/twig/twig.js
+index 9d50c4b..16fe0d7 100644
+--- a/node_modules/twig/twig.js
++++ b/node_modules/twig/twig.js
+@@ -8266,7 +8272,7 @@ module.exports = function (Twig) {
+       }).then(function (fileName) {
+         var embedOverrideTemplate = new Twig.Template({
+           data: token.output,
+-          id: state.template.id,
++          id: `${state.template.id}-override`,
+           base: state.template.base,
+           path: state.template.path,
+           url: state.template.url,


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

- When a chain of three include/embed (include > include > embed) or more within a component are used, storybook will stop rendering and throw a `file.includes is not a function` error

**Test**
- [ ] Review a component that chains together several includes in order to render. The `main menu` component is likely the best one to review as this embeds the default menu which includes the menu item which includes the menu link.