### PR TITLE
test: installs all components during test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,3 +49,4 @@ jobs:
         run: |
           cd emulsify_drupal_starter
           emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout ${{ github.head_ref }}
+          emulsify component install --all


### PR DESCRIPTION
This PR adds a command to install all components during the CLI test so that we're testing everything, not just the required ones.