### PR TITLE
feat: add keyboard trap to modal for ada compliance

### DIFF
--- a/components/02-molecules/modal/modal.js
+++ b/components/02-molecules/modal/modal.js
@@ -3,6 +3,8 @@ Drupal.behaviors.modal = {
     // Variables
     const modals = context.querySelector('.modal');
     let activeModal = context.querySelector('.modal--active');
+    const focusableElements =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
     // Check if an element is completely empty.
     function isEmpty(node) {
@@ -18,6 +20,35 @@ Drupal.behaviors.modal = {
         x = 'true';
       }
       el.setAttribute(`aria-${aria}`, x);
+    }
+
+    // Traps keyboard focus when modal is open for ADA compliance
+    function trapKeyboard(modal) {
+      const firstFocusableElement =
+        modal.querySelectorAll(focusableElements)[0];
+      const focusableContent = modal.querySelectorAll(focusableElements);
+      const lastFocusableElement =
+        focusableContent[focusableContent.length - 1];
+
+      modal.addEventListener('keydown', (e) => {
+        const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+
+        if (!isTabPressed) {
+          return;
+        }
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            e.preventDefault();
+          }
+        } else if (document.activeElement === lastFocusableElement) {
+          firstFocusableElement.focus();
+          e.preventDefault();
+        }
+      });
+
+      firstFocusableElement.focus();
     }
 
     // Toggle tabindex focus attribute.
@@ -42,6 +73,7 @@ Drupal.behaviors.modal = {
       activeModal = context.querySelector('.modal--active');
       toggleAria(modalModalPane, 'hidden');
       toggleAria(modal, 'expanded');
+      trapKeyboard(modalModalPane);
       toggletabIndex(modalModalPane);
     }
 


### PR DESCRIPTION
**Summary**
This adds a keyboard trap when the modal is open so that the component can be ADA WCAG 2.0 compliant. 

When a user opens a modal, this will keep all keyboard focusable elements inside the modal. The reason for this is that a keyboard user may open a modal and tab to content that is outside the modal and therefore not accessible. 

From an example of success criterion in the [WCAG 2.0 guidelines](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html):
> A modal dialog box
> 
> A Web application brings up a dialog box. At the bottom of the dialog are two buttons, Cancel and OK. When the dialog has been opened, focus is trapped within the dialog; tabbing from the last control in the dialog takes focus to the first control in the dialog. The dialog is dismissed by activating the Cancel button or the OK button.

**How to review this PR**
- [ ] [Go to the Storybook modal component](http://localhost:6006/?path=/story/molecules-modal--modal-button) and also add `<p>this is a test</p><p><button>click here</button><p>another test</p>` right after line `49` in `modal.twig`.
- [ ] Notice that when you open the modal, it tabs through the content of the model and not outside of it. 
