### PR TITLE
fix(menu bug): restoring inline, main and social menus

### DIFF
--- a/components/02-molecules/menus/_menu-item.twig
+++ b/components/02-molecules/menus/_menu-item.twig
@@ -25,7 +25,7 @@
 {% import "@molecules/menus/_menu.twig" as menus %}
 
 {% extends "@atoms/lists/_list-item.twig" %}
-  {% block list_item_content %}
+  {% block list__item__content %}
     {# if drupal #}
     {% if directory %}
       {{ link(item.title, item.url, bem(item_base_class|default(menu_class ~ '__link'), item_modifiers)) }}

--- a/components/02-molecules/menus/_menu-item.twig
+++ b/components/02-molecules/menus/_menu-item.twig
@@ -18,9 +18,9 @@
 {% endfor %}
 
 {% set list_item_label = item_label %}
-{% set li_base_class = item_base_class|default(menu_class ~ '__item') %}
-{% set li_modifiers = item_modifiers %}
-{% set li_blockname = item_blockname %}
+{% set list__item__base_class = item_base_class|default(menu_class ~ '__item') %}
+{% set list__item__modifiers = item_modifiers %}
+{% set list__item__blockname = item_blockname %}
 
 {% import "@molecules/menus/_menu.twig" as menus %}
 

--- a/components/02-molecules/menus/_menu-list.twig
+++ b/components/02-molecules/menus/_menu-list.twig
@@ -7,9 +7,9 @@
 {% block list__content %}
   {% for item in items %}
     {% include "@molecules/menus/_menu-item.twig" with {
-      li_base_class: item_base_class,
-      li_modifiers: item_modifiers,
-      li_blockname: item_blockname,
+      list__item__base_class: item_base_class,
+      list__item__modifiers: item_modifiers,
+      list__item__blockname: item_blockname,
     } %}
   {% endfor %}
 {% endblock %}

--- a/components/02-molecules/menus/_menu-list.twig
+++ b/components/02-molecules/menus/_menu-list.twig
@@ -4,12 +4,12 @@
 
 {# List #}
 {% extends "@atoms/lists/list.twig" %}
-  {% block list_content %}
-    {% for item in items %}
-      {% include "@molecules/menus/_menu-item.twig" with {
-        li_base_class: item_base_class,
-        li_modifiers: item_modifiers,
-        li_blockname: item_blockname,
-      } %}
-    {% endfor %}
-  {% endblock %}
+{% block list__content %}
+  {% for item in items %}
+    {% include "@molecules/menus/_menu-item.twig" with {
+      li_base_class: item_base_class,
+      li_modifiers: item_modifiers,
+      li_blockname: item_blockname,
+    } %}
+  {% endfor %}
+{% endblock %}

--- a/components/02-molecules/menus/social/_social-menu-item.twig
+++ b/components/02-molecules/menus/social/_social-menu-item.twig
@@ -1,6 +1,6 @@
-{% set li_base_class = 'item' %}
-{% set li_modifiers = item_modifiers %}
-{% set li_blockname = menu_class %}
+{% set list__item__base_class = 'item' %}
+{% set list__item__modifiers = item_modifiers %}
+{% set list__item__blockname = menu_class %}
 
 {% extends "@atoms/lists/_list-item.twig" %}
   {% block list__item__content %}

--- a/components/02-molecules/menus/social/_social-menu-item.twig
+++ b/components/02-molecules/menus/social/_social-menu-item.twig
@@ -3,6 +3,6 @@
 {% set li_blockname = menu_class %}
 
 {% extends "@atoms/lists/_list-item.twig" %}
-  {% block list_item_content %}
+  {% block list__item__content %}
     {% include "@molecules/menus/social/_social-menu-link.twig" %}
   {% endblock %}

--- a/components/02-molecules/menus/social/social-menu.twig
+++ b/components/02-molecules/menus/social/social-menu.twig
@@ -6,7 +6,7 @@
 
 {# List #}
 {% extends "@atoms/lists/list.twig" %}
-  {% block list_content %}
+  {% block list__content %}
     {% for item in social_menu_items %}
       {% include "@molecules/menus/social/_social-menu-item.twig" %}
     {% endfor %}


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- Missing Inline Menu links
- Missing Main Menu links
- Missing Social Menu links

These three menus were using {% block %} names that were not correct

- [ ] View Molecules -> Menu -> Inline
- [ ] View Molecules -> Menu -> Main
- [ ] View Molecules -> Menu -> Social
- [ ] Confirm the menus all appear properly
