### PR TITLE
Feat: JSdoc Eslint Plugin

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,10 +3,12 @@ extends:
   - airbnb-base
   - plugin:security/recommended
   - plugin:prettier/recommended
+  - plugin:jsdoc/recommended
 plugins:
   - security
   - prettier
   - jest
+  - jsdoc
 env:
   es6: true
   browser: true

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ These are the most common npm scripts you may find yourself using:
 (Each is prefixed with `npm run `)
 
 - `develop`
-- Initializes [Webpack](https://webpack.js.org/) to compile existing files and watch for additional changes. It also starts an instance of [storybook](https://storybook.js.org/) that auto-refreshes when file changes are detected.
+Initializes [Webpack](https://webpack.js.org/) to compile existing files and watch for additional changes. It also starts an instance of [storybook](https://storybook.js.org/) that auto-refreshes when file changes are detected.
 
 - `lint`
-- Runs [stylelint](https://stylelint.io/) for your sass files and [eslint](https://eslint.org/) for your javascript files. The eslint configuration enforces formatting based on [prettier](https://prettier.io/docs/en/index.html) and javascript comments according to [JSdoc](https://jsdoc.app/).
+Runs [stylelint](https://stylelint.io/) for your sass files and [eslint](https://eslint.org/) for your javascript files. The eslint configuration enforces formatting based on [prettier](https://prettier.io/docs/en/index.html) and javascript comments according to [JSdoc](https://jsdoc.app/).
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ When you do, remember to add it to the `system.emulsify.json` file so that it's 
 
 If the component has dependencies, be sure to identify them, so that the CLI knows to install them as well. Here's an example of the card component declaring its dependencies:
 
+### Common Scripts
+
+These are the most common npm scripts you may find yourself using:
+(Each is prefixed with `npm run `)
+
+- `develop`
+- Initializes [Webpack](https://webpack.js.org/) to compile existing files and watch for additional changes. It also starts an instance of [storybook](https://storybook.js.org/) that auto-refreshes when file changes are detected.
+
+- `lint`
+- Runs [stylelint](https://stylelint.io/) for your sass files and [eslint](https://eslint.org/) for your javascript files. The eslint configuration enforces formatting based on [prettier](https://prettier.io/docs/en/index.html) and javascript comments according to [JSdoc](https://jsdoc.app/).
+
+
 ```
 {
   "name": "card",

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ If the component has dependencies, be sure to identify them, so that the CLI kno
 ### Common Scripts
 
 These are the most common npm scripts you may find yourself using:
-(Each is prefixed with `npm run `)
+(Each is prefixed with `npm run`)
 
-- `develop`
+- `develop`<br>
 Initializes [Webpack](https://webpack.js.org/) to compile existing files and watch for additional changes. It also starts an instance of [storybook](https://storybook.js.org/) that auto-refreshes when file changes are detected.
 
-- `lint`
+- `lint`<br>
 Runs [stylelint](https://stylelint.io/) for your sass files and [eslint](https://eslint.org/) for your javascript files. The eslint configuration enforces formatting based on [prettier](https://prettier.io/docs/en/index.html) and javascript comments according to [JSdoc](https://jsdoc.app/).
 
 

--- a/components/02-molecules/tabs/tabs.js
+++ b/components/02-molecules/tabs/tabs.js
@@ -7,8 +7,9 @@ Drupal.behaviors.tabs = {
 
     /**
      * goToTab
+     *
      * @description Goes to a specific tab based on index. Returns nothing.
-     * @param {Number} index The index of the tab to go to
+     * @param {number} index The index of the tab to go to
      */
     function goToTab(index) {
       if (
@@ -26,10 +27,11 @@ Drupal.behaviors.tabs = {
 
     /**
      * handleClick
+     *
      * @description Handles click event listeners on each of the links in the
      *   tab navigation. Returns nothing.
      * @param {HTMLElement} link The link to listen for events on
-     * @param {Number} index The index of that link
+     * @param {number} index The index of that link
      */
     function handleClick(link, index) {
       link.addEventListener('click', (e) => {
@@ -40,6 +42,7 @@ Drupal.behaviors.tabs = {
 
     /**
      * init
+     *
      * @description Initializes the component by removing the no-js class from
      *   the component, and attaching event listeners to each of the nav items.
      *   Returns nothing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "compound",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "compound",
-      "version": "1.0.0",
+      "version": "0.0.0-development",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@babel/eslint-parser": "^7.12.17",
@@ -44,6 +45,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jest": "^24.1.0",
+        "eslint-plugin-jsdoc": "^39.3.6",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.21.5",
@@ -2384,6 +2386,20 @@
       },
       "peerDependencies": {
         "cosmiconfig": ">=6"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -8686,12 +8702,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001261",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001415",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
+      "integrity": "sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -9285,6 +9308,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/commondir": {
@@ -10563,8 +10595,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -11729,6 +11762,7 @@
     },
     "node_modules/eslint": {
       "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -11988,6 +12022,54 @@
         "@typescript-eslint/eslint-plugin": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "39.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz",
+      "integrity": "sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -16689,6 +16771,15 @@
         "un-eval": "^1.2.0"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
@@ -21364,6 +21455,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -32237,6 +32333,17 @@
         "tslib": "^2"
       }
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
@@ -37013,8 +37120,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001261",
-      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA=="
+      "version": "1.0.30001415",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
+      "integrity": "sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -37459,6 +37567,12 @@
     "commander": {
       "version": "6.2.1",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true
     },
     "commondir": {
@@ -38467,8 +38581,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -39370,6 +39485,7 @@
     },
     "eslint": {
       "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -39626,6 +39742,38 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "39.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz",
+      "integrity": "sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -43031,6 +43179,12 @@
         "loader-utils": "^1.2.3",
         "un-eval": "^1.2.0"
       }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.21.5",


### PR DESCRIPTION
**Summary**
Adds a new plugin to existing Eslint setup that allows us to check formatting of javascript comments. See: https://jsdoc.app/about-getting-started.html 

Explain the **motivation** for making this change. What existing problem does the pull request solve?
- JS commenting can vary greatly between components or not be present at all. This plugin allows us to enforce a standard that is easy to read and useful for new devs to understand existing component JS.

**Documentation Update (required)**
- No documentation updates are needed. This new plugin automatically runs when `npm run lint-js` is fired.

**How to review this PR**
- [x] Checkout branch and run `npm install`
- [x] run `npm run lint-js` and verify you see the following warnings related to the existing Tabs component.
![Screenshot from 2022-10-04 08-29-42](https://user-images.githubusercontent.com/369018/193835866-bcaf7878-7633-43d3-8f22-757375a7d721.png)
- [x] Verify the file changes look appropriate and we are extended the recommended rules found here: https://github.com/gajus/eslint-plugin-jsdoc#configuration 
- [x] Once the above is test please comment in the PR and I will then include a commit that fixes those warnings for our Tab component.

