### PR TITLE
fix(69): removing check for alt attr before printing it

### DIFF
--- a/components/01-atoms/images/image/_image.twig
+++ b/components/01-atoms/images/image/_image.twig
@@ -9,9 +9,7 @@
     sizes="{{ image_sizes }}"
   {% endif %}
   src="{{ image_src }}"
-  {% if image_alt %}
-    alt="{{ image_alt }}"
-  {% endif %}
+  alt="{{ image_alt }}"
   {% if image_title %}
     title="{{ image_title }}"
   {% endif %}


### PR DESCRIPTION
This PR fixes/implements the following **bugs/features**

- Images are currently printing no alt attribute when they should be printing empty alt attributes.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

 "If there is no alt attribute on the <img> element, the screen reader will announce the name of the image file, which may not make any sense to the user." So for images that don't have any alt attribute, the preference is the image information not be read at all. Images that are NOT decorative should have alt text. 

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [x] Include an image.twig embed in another component's twig template.
- [x] In the component's yml file, set the `alt` attribute to empty quotation marks. 
- [x] Verify that the image's alt attribute is printing, but empty.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #69
