### PR TITLE
fix: name variable fixed for using double underscore

### DIFF
--- a/components/01-atoms/images/icons/icons.md
+++ b/components/01-atoms/images/icons/icons.md
@@ -17,7 +17,7 @@ Simple: (no BEM renaming)
 
 ```
 {% include "@atoms/images/icons/_icon.twig" with {
-  icon_name: 'menu',
+  icon__name: 'menu',
 } %}
 ```
 
@@ -36,7 +36,7 @@ Complex (BEM classes):
 {% include "@atoms/04-images/icons/_icon.twig" with {
   icon_base_class: 'toggle',
   icon_blockname: 'main-nav',
-  icon_name: 'menu',
+  icon__name: 'menu',
 } %}
 ```
 

--- a/components/01-atoms/images/icons/icons.twig
+++ b/components/01-atoms/images/icons/icons.twig
@@ -2,7 +2,7 @@
   {% for item in icons %}
     <div class="icons-demo__item">
       {% include "@atoms/images/icons/_icon.twig" with {
-        icon_name: item
+        icon__name: item
       } %}
       <pre>{{ item }}</pre>
     </div>


### PR DESCRIPTION
## Summary
The [icons component](http://localhost:6006/?path=/story/atoms-images--icons) was not showing the icon images, it was due that the name variable was change for using two underscore (`icon__name`) so this was fixed here

## How to review this pull request
- [ ] On you local go to the [icons component](http://localhost:6006/?path=/story/atoms-images--icons)
- [ ] The icon images should be visible

<img width="1561" alt="Screen Shot 2022-12-17 at 12 23 24 AM" src="https://user-images.githubusercontent.com/9342250/208204444-cd5e321b-c15e-4765-9831-ba920cd707b8.png">

