### PR TITLE
fix(74): fixing select color contrast

### DIFF
--- a/components/01-atoms/forms/select/_select.scss
+++ b/components/01-atoms/forms/select/_select.scss
@@ -1,7 +1,7 @@
 // CSS-only select styling (from https://github.com/filamentgroup/select-css)
 
 .form-item__dropdown {
-  border: 1px solid clr(muted);
+  border: 1px solid clr(accent);
   display: block;
   position: relative;
 

--- a/components/01-atoms/forms/select/_select.scss
+++ b/components/01-atoms/forms/select/_select.scss
@@ -30,7 +30,7 @@
 }
 
 .form-item__select {
-  border: 1px solid clr(muted);
+  border: 1px solid clr(accent);
   height: 41px; // set height required for discrepancy between .form-item__dropdown border and the select :focus border
   font-size: 16px;
   margin: 0;


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- Visual boundary of the select combobox lacks 3 to 1 color contrast.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Non text elements like boundaries, focus indicators, icons must have at least 3 to 1 color contrast against the background

## Documentation update (required)

If this pull request requires a change to Emulsify documentation, those changes, updates, and/or new information must accompany this pull request.

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [x] Using Chrome, Open `?path=/story/atoms-forms--select-dropdowns`
- [x] Now measure the color contrast for the boundary of the dropdown against the background white color
- [x] Check that the border has adequate color contrast (now, using the accent variable, it is #4c4c4c to #ffffff

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #74 
