### PR TITLE
fix(76): placeholder-text-contrast

### DIFF
--- a/components/01-atoms/forms/textfields/_textfields.scss
+++ b/components/01-atoms/forms/textfields/_textfields.scss
@@ -27,7 +27,7 @@
   }
 
   &::placeholder {
-    color: clr(highlight);
+    color: clr(text);
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- Placeholder text in textfields lacks 4.5 to 1 color contrast

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Regular text (under 18 point regular font or 14 point bold font) including placeholder text must have a contrast ratio of at least 4.5 to 1 with the background.

## Documentation update (required)

If this pull request requires a change to Emulsify documentation, those changes, updates, and/or new information must accompany this pull request.

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Using Chrome, Open https://emulsify-ds.github.io/compound/?path=/story/atoms-forms--textfields-examples
- [ ] Now measure the color contrast for the placeholder text of all the text field against the background white color.
- [ ] Ensure that the placeholder text is the proper contrast (#666666 to #ffffff) 

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #76
