### PR TITLE
Fix button text not showing on button

### DIFF
--- a/components/01-atoms/buttons/button-alt.yml
+++ b/components/01-atoms/buttons/button-alt.yml
@@ -1,4 +1,4 @@
-button_content: 'Alternative Button'
+button__content: 'Alternative Button'
 button_url: '#'
 button_modifiers:
   - 'alt'

--- a/components/01-atoms/buttons/button.twig
+++ b/components/01-atoms/buttons/button.twig
@@ -1,10 +1,10 @@
 {#
 /**
  * Available variables:
- * - button_content - the content of the button (typically text)
+ * - button__content - the content of the button (typically text)
  *
  * Available blocks:
- * - button_content - used to replace the content of the button with something other than text
+ * - button__content - used to replace the content of the button with something other than text
  *   for example: to insert an icon
  */
 #}

--- a/components/01-atoms/buttons/button.yml
+++ b/components/01-atoms/buttons/button.yml
@@ -1,2 +1,2 @@
-button_content: 'Twig Button'
+button__content: 'Twig Button'
 button_url: '#'

--- a/components/02-molecules/card/card.twig
+++ b/components/02-molecules/card/card.twig
@@ -109,7 +109,7 @@
         button_modifiers: card__button__modifiers,
         button_blockname: card__base_class,
         button_attributes: card__button__attributes,
-        button_content: card__button__content,
+        button__content: card__button__content,
         button_url: card__button__url,
       } %}
     {% endif %}

--- a/components/02-molecules/cta/cta.twig
+++ b/components/02-molecules/cta/cta.twig
@@ -2,6 +2,6 @@
 <div {{ bem(cta__base_class, cta__modifiers, cta__blockname, cta__extra_classes) }}>
   <h2>{{ cta__heading }}</h2>
   {% include "@atoms/buttons/button.twig" with {
-    button_content: cta__button_text,
+    button__content: cta__button_text,
   } %}
 </div>


### PR DESCRIPTION
## Summary

Button text was not showing on the button component

This PR fixes/implements the following **bugs/features**

- Fixes typo of `button_content` to `button__content` across button, CTA and Card components.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When adding a button component, text was not showing up on the button itself.

## Documentation update (required)

Documentation on `button.twig` has been updated as part of this PR.

## How to review this pull request
- [x] View the Storybook instance and navigate to the button component
- [ ] Verify that text shows in the button
- [ ] Navigate to the CTA Example and verify that the button text also shows up