### PR TITLE
fix(92): replacing deprecated spaceless tag

### DIFF
--- a/components/01-atoms/forms/_select-element.twig
+++ b/components/01-atoms/forms/_select-element.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_select()
  */
 #}
-{% spaceless %}
+{% apply spaceless %}
   <div class="form-item__dropdown">
     <select{{ attributes.addClass('form-item__select') }}>
       {% for option in options %}
@@ -26,4 +26,4 @@
       {% endfor %}
     </select>
   </div>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

https://github.com/emulsify-ds/compound/issues/92

Replaces `{% spaceless $}` tag with `{% apply spaceless %}` 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When using the deprecated spaceless tag, the select component breaks the page in Drupal. See this Drupal.org issue: https://www.drupal.org/project/drupal/issues/3094850

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Because this doesn't appear as an error in Storybook, you will need to set up a Drupal site with Compound
- [ ] Add a webform
- [ ] Add a select to the webform
- [ ] Ensure that the select no longer breadks the webform page in Drupal.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #92 
