### PR TITLE
Fix: Make tabs component required

### DIFF
--- a/system.emulsify.json
+++ b/system.emulsify.json
@@ -197,6 +197,7 @@
         {
           "name": "tabs",
           "structure": "molecules",
+          "required": true,
           "dependency": []
         },
         {


### PR DESCRIPTION
## Summary
This PR fixes/implements the following issue: [[BUG] Drupal 9 install theme is incompatible, missing @molecules/tabs/tabs.twig](https://github.com/emulsify-ds/emulsify-cli/issues/218):

- Makes the `tabs` molecule component required
- The `core` keyword error presented in the issue has already been fixed

I'm making the `tabs` component required because it is being used in the `menu-local-tasks.html.twig` Drupal template. As of right now, the `tabs` component is not required, which makes the newly created theme not able to work in Drupal. An error is thrown when the theme is used in Drupal. See:

![image](https://github.com/emulsify-ds/compound/assets/37127345/712e0129-2acd-41ad-9cb7-57341cdf5ec8)

Making the `tabs` component required allows for the theme to being able to be installed, because the component is installed by default by compound.

## Documentation update (required)

No documentation update is required.

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] In your own Drupal project, create a new theme.
   - [ ] Example: `emulsify init "New Theme"`
- [ ] Inside the new theme, install compound.
   - [ ] Run this command: `emulsify system install -r https://github.com/emulsify-ds/compound.git -c fix-issue-218--missing-component`
- [ ] In Drupal, install and set the theme as default.
- [ ] Go to the homepage.
- [ ] No error should've been thrown and the theme should be running.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes [#218](https://github.com/emulsify-ds/emulsify-cli/issues/218)
